### PR TITLE
Add support for CubeTex version 2

### DIFF
--- a/core/grim/src/scene/cube_tex/mod.rs
+++ b/core/grim/src/scene/cube_tex/mod.rs
@@ -5,10 +5,20 @@ use grim_macros::*;
 use grim_traits::scene::*;
 pub use io::*;
 
+pub struct CubeTexProperties {
+    pub bpp: u32,
+    pub width: u32,
+    pub height: u32,
+    pub num_mip_maps: u32,
+    pub bitmap_encoding: u32, // DXT5, RGBA, etc.
+}
+
 #[milo]
 pub struct CubeTexObject {
     pub some_num_1: u32,
     pub some_num_2: u32,
+
+    pub properties: Vec<CubeTexProperties>,
 
     pub right_ext_path: String,
     pub left_ext_path: String,
@@ -38,6 +48,8 @@ impl Default for CubeTexObject {
             // CubeTex object
             some_num_1: 64,
             some_num_2: 4,
+
+            properties: Vec::new(),
 
             right_ext_path: String::default(),
             left_ext_path: String::default(),


### PR DESCRIPTION
Implemented support for CubeTex version 2 objects. The differences are quite minor, there is a new CubeTexProperties structure in version 2 (of which there are always 7 in an array, I assume one for the cubemap as a whole + one for each face of it) which just contains data from the bitmaps like the bytes per pixel and bitmap encoding.

Triple-checked all of this to be accurate but please let me know if you spot any errors in my Rust code as I am newer to Rust. It does compile + the preview UI now opens scenes containing V2 CubeTex objects properly, but feel free to change anything I am not doing optimally here.